### PR TITLE
Load settings from env vars & sort deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "anyhow",
  "cached",
  "cookie",
+ "dotenv",
  "reqwest",
  "serde",
  "tokio",
@@ -311,6 +312,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,15 @@ authors = ["Sm03leBr00t <Sm03leBr00t@protonmail.com>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.118", features = ["derive"] }
-cookie = "0.14.3"
 anyhow = "1.0.35"
+cached = "0.22.0"
+cookie = "0.14.3"
+dotenv = "0.15.0"
+reqwest = { version = "0.10.9", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1.0.118", features = ["derive"] }
 tokio = { version = "0.2.23", features = ["macros"] }
 twilight-cache-inmemory = "0.2.3"
+twilight-embed-builder = "0.2.0"
 twilight-gateway = "0.2.5"
 twilight-http = "0.2.5"
 twilight-model = "0.2.4"
-twilight-embed-builder = "0.2.0"
-cached = "0.22.0"
-reqwest = { version = "0.10.9", default-features = false, features = ["json", "rustls-tls"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
+use std::env;
 use std::error::Error;
 
 use cached::proc_macro::cached;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use aoc_bot::YearEvent;
 use reqwest::header;
 use tokio::stream::StreamExt;
@@ -17,11 +18,14 @@ use twilight_model::gateway::Intents;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+
     println!("Configuring ...");
-    let lid = "975781".to_string();
-    // TODO: insert tokens here
-    let session_cookie = "".to_string();
-    let token = "".to_string();
+    let lid = env::var("AOC_BOARD_ID").context("AOC_BOARD_ID env var missing")?;
+    let session_cookie =
+        env::var("AOC_SESSION_COOKIE").context("AOC_SESSION_COOKIE env var missing")?;
+    let token = env::var("DISCORD_BOT_TOKEN").context("DISCORD_BOT_TOKEN env var missing")?;
+
     println!("Starting ...");
 
     // This is the default scheme. It will automatically create as many


### PR DESCRIPTION
This loads the 3 required values **board id**, **session cookie** and **bot token** from env vars instead of having to put them into the code directly.

The values can either be loaded directly from the environment or from a `.env` file thanks to the `direnv` crate.

I sorted the dependencies while adding direnv as well.