### PR TITLE
Don't panic if getting aoc data fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::error::Error;
 
 use cached::proc_macro::cached;
 
@@ -67,13 +66,19 @@ async fn main() -> Result<()> {
         // Update the cache with the event.
         cache.update(&event);
 
-        tokio::spawn(handle_event(
+        let fut = handle_event(
             shard_id,
             event,
             http.clone(),
             lid.clone(),
             session_cookie.clone(),
-        ));
+        );
+
+        tokio::spawn(async {
+            if let Err(e) = fut.await {
+                eprintln!("failed handling event: {}", e);
+            }
+        });
     }
 
     Ok(())


### PR DESCRIPTION
This removes the `unwrap` calls in `get_aoc_data` and propagates the error up instead.
The `result = true` flag ensures that results are only cached if the call was successful (no error).

I slightly changed the call to `handle_event` as well so we get some nice error output when something goes wrong in the task.