### PR TITLE
Add the time of latest challenge solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cached",
+ "chrono",
  "config",
  "cookie",
  "dotenv",
@@ -210,6 +211,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
+ "serde 1.0.118",
  "time 0.1.44",
  "winapi 0.3.9",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,17 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.35"
 cached = "0.22.0"
+chrono = { version = "0.4.19", features = ["serde"] }
+config = "0.10.1"
 cookie = "0.14.3"
 dotenv = "0.15.0"
+log = "0.4.11"
 reqwest = { version = "0.10.9", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.118", features = ["derive"] }
+simplelog = "0.8.0"
 tokio = { version = "0.2.23", features = ["macros"] }
 twilight-cache-inmemory = "0.2.3"
 twilight-embed-builder = "0.2.0"
 twilight-gateway = "0.2.5"
 twilight-http = "0.2.5"
 twilight-model = "0.2.4"
-simplelog = "0.8.0"
-log = "0.4.11"
-config = "0.10.1"

--- a/src/aoc/de.rs
+++ b/src/aoc/de.rs
@@ -1,0 +1,32 @@
+//! Custom deserializers for response fields of the AoC API.
+
+use std::fmt;
+
+use chrono::prelude::*;
+use serde::de::{self, Deserializer, Visitor};
+
+/// Deserialize a UNIX timestamp that is encoded as string instead of an integer.
+pub fn string_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_str(TimestampVisitor)
+}
+
+struct TimestampVisitor;
+
+impl<'de> Visitor<'de> for TimestampVisitor {
+    type Value = DateTime<Utc>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a UNIX timestamp encoded as string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let ts = v.parse::<i64>().map_err(|e| E::custom(e.to_string()))?;
+        Ok(Utc.timestamp(ts, 0))
+    }
+}

--- a/src/aoc/mod.rs
+++ b/src/aoc/mod.rs
@@ -1,9 +1,14 @@
+//! Advent of Code API to retrieve leaderboard statistics.
+
 use std::collections::HashMap;
 
 use anyhow::Result;
+use chrono::prelude::*;
 use cookie::Cookie;
 use reqwest::header;
 use serde::Deserialize;
+
+mod de;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct LeaderboardStats {
@@ -32,9 +37,12 @@ pub struct Day {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Challenge {
-    pub get_star_ts: String,
+    #[serde(deserialize_with = "de::string_timestamp")]
+    pub get_star_ts: DateTime<Utc>,
 }
 
+/// Get the latest statistics from a private leaderboard. It is asked by the AoC website owners to
+/// not request this data more often than every 15 minutes.
 pub async fn get_private_leaderboard_stats(
     session_cookie: &str,
     event: u16,


### PR DESCRIPTION
This adds the time of latest challenge completion to the `!aoc` command response.

It's based on #14 which is itself based on another PR so please don't merge this directly and tell me once the other PRs are merged so I can rebase this 🙇.