### PR TITLE
Refactor discord integration and add schedule

### DIFF
--- a/config/auth.toml
+++ b/config/auth.toml
@@ -1,8 +1,12 @@
 # Fill in the authentication values here or pass them as env vars with AOC_BOARD_ID,
 # AOC_SESSION_COOKIE and DISCORD_BOT_TOKEN.
 [aoc]
-board_id=""
-session_cookie=""
+board_id = ""
+session_cookie = ""
 
 [discord]
-bot_token=""
+bot_token = ""
+
+[discord.schedule]
+interval = 7200
+channel_id = 0

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use log::{debug, error, info};
+use tokio::stream::StreamExt;
+use tokio::sync::mpsc::Sender;
+use twilight_cache_inmemory::{EventType, InMemoryCache};
+use twilight_gateway::{
+    cluster::{Cluster, ShardScheme},
+    Event,
+};
+use twilight_http::Client as HttpClient;
+use twilight_model::user::User;
+use twilight_model::{channel::Message, gateway::Intents};
+
+use crate::settings::Discord;
+
+pub async fn start(settings: &Discord, sender: Sender<crate::models::Event>) -> Result<()> {
+    // This is the default scheme. It will automatically create as many
+    // shards as is suggested by Discord.
+    let scheme = ShardScheme::Auto;
+    debug!("Using scheme : {:?}", scheme);
+
+    // Use intents to only receive guild message events.
+    let cluster = Cluster::builder(settings.bot_token.clone(), Intents::GUILD_MESSAGES)
+        .shard_scheme(scheme)
+        .build()
+        .await?;
+
+    debug!("Cluster set up");
+
+    // Start up the cluster.
+    let cluster_spawn = cluster.clone();
+
+    // Start all shards in the cluster in the background.
+    tokio::spawn(async move {
+        debug!("Spawning cluster");
+        cluster_spawn.up().await;
+
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            error!("Failed setting up CTRL+C listener: {}", e);
+        }
+
+        debug!("Stopping cluster");
+        cluster_spawn.down();
+    });
+
+    // Since we only care about new messages, make the cache only
+    // cache new messages.
+    debug!("Setting up cache for twilight");
+    let cache = InMemoryCache::builder()
+        .event_types(
+            EventType::MESSAGE_CREATE
+                | EventType::MESSAGE_DELETE
+                | EventType::MESSAGE_DELETE_BULK
+                | EventType::MESSAGE_UPDATE,
+        )
+        .build();
+
+    // Handle Discord events on a separate task.
+    tokio::spawn(handle_events(cluster, cache, sender));
+
+    Ok(())
+}
+
+async fn handle_events(
+    cluster: Cluster,
+    cache: InMemoryCache,
+    mut sender: Sender<crate::models::Event>,
+) {
+    let mut events = cluster.events();
+
+    while let Some((shard_id, event)) = events.next().await {
+        debug!("{} | Received event : {:?}", shard_id, event);
+        cache.update(&event);
+
+        match event {
+            Event::MessageCreate(msg) => {
+                let msg = match msg.content.as_str() {
+                    "!ping" => crate::models::Event::Ping((shard_id, msg.0).into()),
+                    "!aoc" => crate::models::Event::AdventOfCode((shard_id, msg.0).into()),
+                    "!42" => crate::models::Event::FourtyTwo((shard_id, msg.0).into()),
+                    _ => continue,
+                };
+
+                if sender.send(msg).await.is_err() {
+                    return;
+                }
+            }
+            Event::ShardConnected(conn) => info!("Connected on shard {}", conn.shard_id),
+            _ => {}
+        }
+    }
+
+    sender.send(crate::models::Event::Shutdown).await.ok();
+}
+
+pub fn new_client(settings: &Discord) -> HttpClient {
+    HttpClient::new(settings.bot_token.clone())
+}
+
+impl From<(u64, Message)> for crate::models::Message {
+    fn from((shard_id, m): (u64, Message)) -> Self {
+        Self {
+            shard_id,
+            channel_id: m.channel_id.0,
+            author: Some(m.author.into()),
+        }
+    }
+}
+
+impl From<User> for crate::models::Author {
+    fn from(u: User) -> Self {
+        Self {
+            id: u.id.0,
+            name: u.name,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![deny(rust_2018_idioms, clippy::all)]
 
 pub mod aoc;
+pub mod discord;
+pub mod models;
 pub mod settings;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,20 @@
+#[derive(Debug)]
+pub enum Event {
+    Ping(Message),
+    AdventOfCode(Message),
+    FourtyTwo(Message),
+    Shutdown,
+}
+
+#[derive(Debug)]
+pub struct Message {
+    pub shard_id: u64,
+    pub channel_id: u64,
+    pub author: Option<Author>,
+}
+
+#[derive(Debug)]
+pub struct Author {
+    pub id: u64,
+    pub name: String,
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -63,6 +63,14 @@ pub struct AdventOfCode {
 pub struct Discord {
     /// A token to authenticate against the Discord API as a bot and send messages.
     pub bot_token: String,
+    #[serde(default)]
+    pub schedule: Option<Schedule>,
+}
+
+#[derive(Deserialize)]
+pub struct Schedule {
+    pub interval: u64,
+    pub channel_id: u64,
 }
 
 /// A wrapper for the [LevelFilter] that allows to use it in [serde], as it doesn't provide support


### PR DESCRIPTION
Had this laying around since last year and totally forgot about it 😆 

Still have to review the code myself to make sure there wasn't anything missing but iirc correctly, this was already complete and I was just considering to split it into smaller commits. This is technically 2 changes, reorganizing the code a bit into smaller modules and adding support for scheduled messages.
One didn't really make sense without the other so it' became one big change in the end. I think it's not really worth splitting this up into 2 distinct commits again, unless you want me to.

This changes splits the event logic by using some kind of actor pattern. That means the semantics of where messages come from is separated from the handling logic of the events. It allows to have a single logic core that doesn't care if an event came from either Discord or some background scheduler.